### PR TITLE
stop stripping perfectly good links

### DIFF
--- a/src/parsers/__init__.py
+++ b/src/parsers/__init__.py
@@ -408,12 +408,6 @@ class HTMLParserBase (ParserBase):
 
         """
         
-        for link in xpath (xhtml, '//xhtml:a[@href]'):
-            href = urlparse.urldefrag (link.get ('href'))[0]
-            if href not in manifest:
-                debug ("strip_links: Deleting <a> to %s not in manifest." % href)
-                del link.attrib['href']
-
         for link in xpath (xhtml, '//xhtml:link[@href]'):
             href = link.get ('href')
             if href not in manifest:

--- a/src/writers/EpubWriter.py
+++ b/src/writers/EpubWriter.py
@@ -868,22 +868,6 @@ class Writer (writers.HTMLishWriter):
                 raise
         
         
-    @staticmethod
-    def strip_links (xhtml, manifest):
-        """ Strip all links to images.
-
-        This does not strip inline images, only images that are
-        targets of links. EPUB does not allow that.
-
-        """
-
-        for link in xpath (xhtml, '//xhtml:a[@href]'):
-            href = urlparse.urldefrag (link.get ('href'))[0]
-            if not manifest[href] in OPS_CONTENT_DOCUMENTS:
-                debug ("strip_links: Deleting <a> to non-ops-document-type: %s" % href)
-                del link.attrib['href']
-                continue
-
                 
     @staticmethod
     def strip_ins (xhtml):
@@ -1232,7 +1216,6 @@ class Writer (writers.HTMLishWriter):
 
                     # strip all links to items not in manifest
                     p.strip_links (xhtml, self.spider.dict_urls_mediatypes ())
-                    self.strip_links (xhtml, self.spider.dict_urls_mediatypes ())
 
                     # FIXME: remove strip_ins when epubcheck is fixed
                     # epubcheck 1.0.4 is broken


### PR DESCRIPTION
Epubmaker source thinks that external links aren't allowed in EPUB.
This is not true any more, at least since EPUB 2.0.1

