### PR TITLE
Stop using  __builtins__ to do global options

### DIFF
--- a/epubmaker/CommonOptions.py
+++ b/epubmaker/CommonOptions.py
@@ -22,6 +22,18 @@ import os
 class Struct (object):
     pass
 
+# options is a "Borg" set by optparse (note that it's not thread-safe)
+class Options:
+    __shared_state = {}
+    def __init__(self):
+        self.__dict__ = self.__shared_state
+        
+    def update(self, _dict):
+        self.__dict__.update(_dict)
+
+options = Options()
+
+
 def add_common_options (op):
     """ Add options common to all programs. """
     
@@ -61,8 +73,9 @@ def get_parser (**kwargs):
     
 
 def parse_args (op, params = {}, defaults = {}):
-    (options, args) = op.parse_args ()
-
+    (parsed_options, args) = op.parse_args ()
+    options.update(vars(parsed_options))
+    
     cp = ConfigParser.SafeConfigParser (params)
     cp.read ( [options.config_name,
                os.path.expanduser ('~/.epubmaker.conf'),

--- a/epubmaker/EpubMaker.py
+++ b/epubmaker/EpubMaker.py
@@ -266,7 +266,10 @@ def main ():
         if options.include_argument:
             options.include = options.include_argument[:]
         else:
-            options.include = [ os.path.dirname (url) + '/*' ]
+            exclude_patt = os.path.dirname (url) + '/*'
+            options.include = [ exclude_patt ]
+            if exclude_patt.startswith ('/'):
+                options.include.append('file://' + exclude_patt)
             
         # try to get metadata
 

--- a/epubmaker/EpubMaker.py
+++ b/epubmaker/EpubMaker.py
@@ -35,6 +35,8 @@ from epubmaker import CommonOptions
 
 from epubmaker.Version import VERSION
 
+options = CommonOptions.Options()
+
 def null_translation (s):
     """ Translate into same language. :-) """
     return s
@@ -228,10 +230,6 @@ def main ():
 
     if not args:
         op.error ("please specify which file to convert")
-
-    import __builtin__
-    __builtin__.options = options
-    __builtin__._ = null_translation
 
     Logger.set_log_level (options.verbose)        
 

--- a/epubmaker/HTMLChunker.py
+++ b/epubmaker/HTMLChunker.py
@@ -26,7 +26,9 @@ from lxml import etree
 import epubmaker.lib.GutenbergGlobals as gg
 from epubmaker.lib.GutenbergGlobals import NS
 from epubmaker.lib.Logger import debug, error
+from epubmaker.CommonOptions import Options
 
+options = Options()
 # MAX_CHUNK_SIZE  = 300 * 1024  # bytes
 MAX_CHUNK_SIZE  = 100 * 1024  # bytes
 

--- a/epubmaker/ParserFactory.py
+++ b/epubmaker/ParserFactory.py
@@ -22,6 +22,9 @@ from epubmaker.mydocutils import broken
 from epubmaker.lib.Logger import debug, error
 from epubmaker.lib.MediaTypes import mediatypes
 from epubmaker.Version import VERSION
+from epubmaker.CommonOptions import Options
+
+options = Options()
 
 class AppURLopener (urllib.FancyURLopener):
     version = "ebookmaker/%s" % VERSION

--- a/epubmaker/parsers/GutenbergTextParser.py
+++ b/epubmaker/parsers/GutenbergTextParser.py
@@ -23,6 +23,9 @@ from epubmaker.lib.MediaTypes import mediatypes as mt
 
 from epubmaker import parsers
 from epubmaker.parsers import HTMLParserBase
+from epubmaker.CommonOptions import Options
+
+options = Options()
 
 mediatypes = (mt.txt, )
 

--- a/epubmaker/parsers/RSTParser.py
+++ b/epubmaker/parsers/RSTParser.py
@@ -42,6 +42,9 @@ from epubmaker.mydocutils.writers import xhtml1, epub2, xetex
 
 from epubmaker.mydocutils.gutenberg import parsers as gutenberg_parsers
 from epubmaker.mydocutils.gutenberg.writers import nroff as gutenberg_nroff
+from epubmaker.CommonOptions import Options
+
+options = Options()
 
 mediatypes = (mt.rst, )
 

--- a/epubmaker/writers/EpubWriter.py
+++ b/epubmaker/writers/EpubWriter.py
@@ -39,6 +39,7 @@ from epubmaker import Spider
 from epubmaker import parsers
 from epubmaker import writers
 from epubmaker.Version import VERSION, GENERATOR
+from epubmaker.CommonOptions import Options
 
 # pylint: disable=W0142
 
@@ -156,6 +157,7 @@ IMAGE_WRAPPER = """<?xml version="1.0"?>
   </body>
 </html>"""
 
+options = Options()
 
 class OEBPSContainer (zipfile.ZipFile):
     """ Class representing an OEBPS Container. """

--- a/epubmaker/writers/HTMLWriter.py
+++ b/epubmaker/writers/HTMLWriter.py
@@ -26,6 +26,9 @@ from epubmaker.lib.GutenbergGlobals import xpath
 from epubmaker.lib.Logger import info, debug, error, exception
 
 from epubmaker import writers
+from epubmaker.CommonOptions import Options
+
+options = Options()
 
 
 class Writer (writers.HTMLishWriter):

--- a/epubmaker/writers/KindleWriter.py
+++ b/epubmaker/writers/KindleWriter.py
@@ -18,6 +18,9 @@ import subprocess
 from epubmaker.lib.Logger import info, debug, warn, error
 from epubmaker.lib.GutenbergGlobals import SkipOutputFormat
 from epubmaker.writers import EpubWriter
+from epubmaker.CommonOptions import Options
+
+options = Options()
 
 
 class Writer (EpubWriter.Writer):

--- a/epubmaker/writers/PDFWriter.py
+++ b/epubmaker/writers/PDFWriter.py
@@ -22,6 +22,9 @@ from epubmaker.lib.GutenbergGlobals import SkipOutputFormat
 
 from epubmaker import ParserFactory
 from epubmaker import writers
+from epubmaker.CommonOptions import Options
+
+options = Options()
 
 class Writer (writers.BaseWriter):
     """ Class to write PDF. """

--- a/epubmaker/writers/TxtWriter.py
+++ b/epubmaker/writers/TxtWriter.py
@@ -23,6 +23,9 @@ from epubmaker.lib.GutenbergGlobals import SkipOutputFormat
 
 from epubmaker import ParserFactory
 from epubmaker import writers
+from epubmaker.CommonOptions import Options
+
+options = Options()
 
 # map some not-widely-supported characters to more common ones
 u2u = {


### PR DESCRIPTION
As in ebook maker, adding options to builtins seems really dangerous. This PR replaces the builtin options with an options "Borg" class. see https://github.com/gutenbergtools/ebookmaker/pull/1